### PR TITLE
Fix bugs in normalization

### DIFF
--- a/utils/nlp.py
+++ b/utils/nlp.py
@@ -54,14 +54,18 @@ def normalize(text):
             if text[sidx - 1] == '(':
                 sidx -= 1
             eidx = text.find(m[-1], sidx) + len(m[-1])
+            if eidx < len(text) and text[eidx] == ")" and text[sidx] == "(":
+                sidx += 1
             text = text.replace(text[sidx:eidx], ''.join(m))
+            sidx += 1
 
     # normalize postcode
-    ms = re.findall('([a-z]{1}[\. ]?[a-z]{1}[\. ]?\d{1,2}[, ]+\d{1}[\. ]?[a-z]{1}[\. ]?[a-z]{1}|[a-z]{2}\d{2}[a-z]{2})',
+    ms = re.findall('((cb|c\.b|c b|pe|p\.e|p e)[\. ]?\d{1,2}[, ]+\d{1}[\. ]?[a-z]{1}[\. ]?[a-z]{1}|[a-z]{2}\d{2}[a-z]{2})',
                     text)
     if ms:
         sidx = 0
         for m in ms:
+            m = m[0]
             sidx = text.find(m, sidx)
             eidx = sidx + len(m)
             text = text[:sidx] + re.sub('[,\. ]', '', m) + text[eidx:]


### PR DESCRIPTION
1. Normalization of phone number.
    If there are two phone numbers in a sentence and they have the same prefix, the original code will lose some information. Besides, the original code will cause some errors about brackets.
    ```
    text = "If you are in an accident and need help you can contact the police department at Parkside, Cambridge phone (012)23358966 or the hospital on Hills Rd (012-232-45151). "
    old_output = "If you are in an accident and need help you can contact the police department at Parkside, Cambridge phone 01223245151)."
    new_output = "If you are in an accident and need help you can contact the police department at Parkside, Cambridge phone 01223358966 or the hospital on Hills Rd (01223245151)."
    ```

2. Normalization of postcode.
    The original code will cause some errors, such as
    ```
    text = "there are 21 4 star hotels."
    old_output = "there are214star hotels."
    new_output = "there are 21 4 star hotels."
    ```