### PR TITLE
New evaluation scripts for BLEU, Inform & Success

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 3. There is no 1-to-1 mapping between dialogue acts and sentences.
 4. There is no dialogue state tracking labels for police and hospital as these domains are very simple. However, there are no dialogues with these domains in validation and testing sets either.
 5. For the dialogue state tracking experiments please follow the datat processing and scoring scripts from the [TRADE](https://github.com/jasonwu0731/trade-dst) model (Wu et al. 2019).
+6. For the response generation evaluation please consider using the scripts from [this repository](https://github.com/Tomiinek/MultiWOZ_Evaluation).
 
 <h2>Benchmarks</h2>
 <h3>Belief Tracking</h3>


### PR DESCRIPTION
Hello, 

we recently summarized some problems associated with calculating the BLEU score and Inform & Success rates on this dataset. The pre-print is available [here](https://arxiv.org/abs/2106.05555). Besides identifying the differences in the current evaluation, we tried to make an as fair as possible comparison of 13 recent models that we managed to make working. We release our out-of-the-box evaluation scripts and predictions of the models in [this repository](https://github.com/Tomiinek/MultiWOZ_Evaluation). Moreover, we added some metrics concerning the lexical diversity of output texts.

I would like to kindly ask you to add a link or mention about the scripts (I've already added tiny changes into the README file). I hope that it will make future work more comparable and bring more clarity into the context-to-response evaluation.

Thanks