### PR TITLE
Add widely used metric: combined score in the leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 | ------------------ | -----:| -------:| --------:| ---------:| -----------------:| -------------:| -------------:| 
 | Reference corpus &nbsp; | -    | 93.7 | 90.9 | 14.00 | 3.01 | 1407 | 23877 | 
 
-**End-to-end models**, i.e. those that use only the context as input.
+**End-to-end models**, i.e. those that use only the context as input. 
+
+Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
 | Model              | BLEU | Inform  | Success  | Av. len. | CBE | #uniq. words | #uniq. 3-grams |
 | ------------------ | -----:| -------:| --------:| ---------:| -----------------:| -------------:| -------------:| 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 
 **End-to-end models**, i.e. those that use only the context as input. 
 
-###### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
+##### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
 | Model              | BLEU | Inform  | Success  | Av. len. | CBE | #uniq. words | #uniq. 3-grams |
 | ------------------ | -----:| -------:| --------:| ---------:| -----------------:| -------------:| -------------:| 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,16 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 
 ##### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
-| Model              | BLEU | Inform  | Success  | Av. len. | CBE | #uniq. words | #uniq. 3-grams |
-| ------------------ | -----:| -------:| --------:| ---------:| -----------------:| -------------:| -------------:| 
-| DAMD ([paper](https://arxiv.org/abs/1911.10484)\|[code](https://github.com/thu-spmi/damd-multiwoz))  | 16.4 | 57.9 | 47.6 | 14.27 | 1.65 | 212  | 1755  |
-| MinTL ([paper](https://arxiv.org/pdf/2009.12005.pdf)\|[code](https://github.com/zlinao/MinTL)) | **19.4** | 73.7 | 65.4 | 14.78 | 1.81 | 297  | 2525  |
-| UBAR ([paper](https://arxiv.org/abs/2012.03539)\|[code](https://github.com/TonyNemo/UBAR-MultiWOZ))  | 17.6 | **83.4** | 70.3 | 13.54 | 2.10 | 478  | 5238  |
+| Model              | BLEU | Inform  | Success  | Combined Score|Av. len. | CBE | #uniq. words | #uniq. 3-grams |
+| ------------------ | -----:| -------:| --------:| ---------:|---------:| -----------------:| -------------:| -------------:| 
+| DAMD ([paper](https://arxiv.org/abs/1911.10484)\|[code](https://github.com/thu-spmi/damd-multiwoz))  | 16.4 | 57.9 | 47.6 | |14.27 | 1.65 | 212  | 1755  |
+| MinTL ([paper](https://arxiv.org/pdf/2009.12005.pdf)\|[code](https://github.com/zlinao/MinTL)) | **19.4** | 73.7 | 65.4 | |14.78 | 1.81 | 297  | 2525  |
+| UBAR ([paper](https://arxiv.org/abs/2012.03539)\|[code](https://github.com/TonyNemo/UBAR-MultiWOZ))  | 17.6 | **83.4** | 70.3 | |13.54 | 2.10 | 478  | 5238  |
 | SOLOIST ([paper](https://arxiv.org/abs/2005.05298))  | 13.6 | 82.3 | 72.4 | 18.45 | **2.41** | **615**  | **7923**  |
-| AuGPT ([paper](https://arxiv.org/abs/2102.05126)\|[code](https://github.com/ufal/augpt)) | 16.8 | 76.6 | 60.5 | 12.90 | 2.15 | 608  | 5843  |
-| LABES ([paper](https://arxiv.org/pdf/2009.08115v3.pdf)\|[code](https://github.com/thu-spmi/LABES)) | 18.9 | 68.5 | 58.1 | 14.20 | 1.83 | 374  | 3228  |
-| DoTS ([paper](https://arxiv.org/pdf/2103.06648.pdf))  | 16.8 | 80.4 | 68.7 | 14.66 | 2.10 | 411  | 5162  |
-| PPTOD ([paper](https://arxiv.org/abs/2109.14739)\|[code](https://github.com/awslabs/pptod))  | 18.2 | 83.1 | **72.7** | 12.73 | 1.88 | 301  | 2538  |
+| AuGPT ([paper](https://arxiv.org/abs/2102.05126)\|[code](https://github.com/ufal/augpt)) | 16.8 | 76.6 | 60.5 | |12.90 | 2.15 | 608  | 5843  |
+| LABES ([paper](https://arxiv.org/pdf/2009.08115v3.pdf)\|[code](https://github.com/thu-spmi/LABES)) | 18.9 | 68.5 | 58.1 | |14.20 | 1.83 | 374  | 3228  |
+| DoTS ([paper](https://arxiv.org/pdf/2103.06648.pdf))  | 16.8 | 80.4 | 68.7 | |14.66 | 2.10 | 411  | 5162  |
+| PPTOD ([paper](https://arxiv.org/abs/2109.14739)\|[code](https://github.com/awslabs/pptod))  | 18.2 | 83.1 | **72.7** | |12.73 | 1.88 | 301  | 2538  |
 
 **Policy optimization models**, i.e. those that use also the ground-truth dialog states.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 ##### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
 | Model              | BLEU | Inform  | Success  | Combined Score|Av. len. | CBE | #uniq. words | #uniq. 3-grams |
-| ------------------ | -----:| -------:| --------:| ---------:|---------:| -----------------:| -------------:| -------------:|
+| ------------------ | :-----:| :-------:| :--------:| :---------:|:---------:| :-----------------:| :-------------:| :-------------:|
 | MarCo ([paper](https://arxiv.org/pdf/2004.12363.pdf)\|[code](https://github.com/InitialBug/MarCo-Dialog))   | 17.3 | 94.5 | 87.2 | **108.1**|16.01 | **1.94** | 319 | **3002** | 
 | HDSA ([paper](https://arxiv.org/pdf/1905.12866.pdf)\|[code](https://github.com/wenhuchen/HDSA-Dialog))    | **20.7** | 87.9 | 79.4 | 104.4|14.42 | 1.64 | 259 | 2019 |
 | HDNO ([paper](https://arxiv.org/pdf/2006.06814.pdf)\|[code](https://github.com/mikezhang95/HDNO))    | 17.8 | 93.3 | 83.4 | 106.1|14.96 | 0.84 | 103 | 315  |

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 
 | Model              | BLEU | Inform  | Success  | Combined Score|Av. len. | CBE | #uniq. words | #uniq. 3-grams |
 | ------------------ | -----:| -------:| --------:| ---------:|---------:| -----------------:| -------------:| -------------:|
-| MarCo ([paper](https://arxiv.org/pdf/2004.12363.pdf)\|[code](https://github.com/InitialBug/MarCo-Dialog))   | 17.3 | 94.5 | 87.2 | |16.01 | **1.94** | 319 | **3002** | 
-| HDSA ([paper](https://arxiv.org/pdf/1905.12866.pdf)\|[code](https://github.com/wenhuchen/HDSA-Dialog))    | **20.7** | 87.9 | 79.4 | |14.42 | 1.64 | 259 | 2019 |
-| HDNO ([paper](https://arxiv.org/pdf/2006.06814.pdf)\|[code](https://github.com/mikezhang95/HDNO))    | 17.8 | 93.3 | 83.4 | |14.96 | 0.84 | 103 | 315  |
-| SFN ([paper](https://arxiv.org/pdf/1907.10016.pdf)\|[code](https://github.com/Shikib/structured_fusion_networks))     | 14.1 | 93.4 | 82.3 | |14.93 | 1.63 | 188 | 1218 |
-| UniConv ([paper](https://arxiv.org/pdf/2004.14307.pdf)\|[code](https://github.com/henryhungle/UniConv)) | 18.1 | 66.7 | 58.7 | |14.17 | 1.79 | **338** | 2932 |
-| LAVA ([paper](https://arxiv.org/abs/2011.09378)\|[code](https://gitlab.cs.uni-duesseldorf.de/general/dsml/lava-public/-/tree/master/experiments_woz/sys_config_log_model/2020-05-12-14-51-49-actz_cat))    | 10.8 | **95.9** | **93.5** | |13.28 | 1.27 | 176 | 708  |
+| MarCo ([paper](https://arxiv.org/pdf/2004.12363.pdf)\|[code](https://github.com/InitialBug/MarCo-Dialog))   | 17.3 | 94.5 | 87.2 | **108.1**|16.01 | **1.94** | 319 | **3002** | 
+| HDSA ([paper](https://arxiv.org/pdf/1905.12866.pdf)\|[code](https://github.com/wenhuchen/HDSA-Dialog))    | **20.7** | 87.9 | 79.4 | 104.4|14.42 | 1.64 | 259 | 2019 |
+| HDNO ([paper](https://arxiv.org/pdf/2006.06814.pdf)\|[code](https://github.com/mikezhang95/HDNO))    | 17.8 | 93.3 | 83.4 | 106.1|14.96 | 0.84 | 103 | 315  |
+| SFN ([paper](https://arxiv.org/pdf/1907.10016.pdf)\|[code](https://github.com/Shikib/structured_fusion_networks))     | 14.1 | 93.4 | 82.3 | 101.9|14.93 | 1.63 | 188 | 1218 |
+| UniConv ([paper](https://arxiv.org/pdf/2004.14307.pdf)\|[code](https://github.com/henryhungle/UniConv)) | 18.1 | 66.7 | 58.7 | 80.8|14.17 | 1.79 | **338** | 2932 |
+| LAVA ([paper](https://arxiv.org/abs/2011.09378)\|[code](https://gitlab.cs.uni-duesseldorf.de/general/dsml/lava-public/-/tree/master/experiments_woz/sys_config_log_model/2020-05-12-14-51-49-actz_cat))    | 10.8 | **95.9** | **93.5** | 105.5|13.28 | 1.27 | 176 | 708  |
 
 
 ### Older results

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 **End-to-end models**, i.e. those that use only the context as input. 
 ##### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
-| Model              | BLEU | Inform  | Success  | Combined Score|Av. len. | CBE | #uniq. words | #uniq. 3-grams |
+| Model              | BLEU | Inform  | Success  | Combined Score |Av. len. | CBE | #uniq. words | #uniq. 3-grams |
 | ------------------ | :-----:| :-------:| :--------:| :---------:|:---------:| :-----------------:| :-------------:| :-------------:| 
 | DAMD ([paper](https://arxiv.org/abs/1911.10484)\|[code](https://github.com/thu-spmi/damd-multiwoz))  | 16.4 | 57.9 | 47.6 | 84.8|14.27 | 1.65 | 212  | 1755  |
 | MinTL ([paper](https://arxiv.org/pdf/2009.12005.pdf)\|[code](https://github.com/zlinao/MinTL)) | **19.4** | 73.7 | 65.4 | 89.0|14.78 | 1.81 | 297  | 2525  |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 
 **End-to-end models**, i.e. those that use only the context as input. 
 
-Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
+### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
 | Model              | BLEU | Inform  | Success  | Av. len. | CBE | #uniq. words | #uniq. 3-grams |
 | ------------------ | -----:| -------:| --------:| ---------:| -----------------:| -------------:| -------------:| 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 ##### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
 | Model              | BLEU | Inform  | Success  | Combined Score|Av. len. | CBE | #uniq. words | #uniq. 3-grams |
-| ------------------ | -----:| -------:| --------:| ---------:|---------:| -----------------:| -------------:| -------------:| 
+| ------------------ | :-----:| :-------:| :--------:| :---------:|:---------:| :-----------------:| :-------------:| :-------------:| 
 | DAMD ([paper](https://arxiv.org/abs/1911.10484)\|[code](https://github.com/thu-spmi/damd-multiwoz))  | 16.4 | 57.9 | 47.6 | 84.8|14.27 | 1.65 | 212  | 1755  |
 | MinTL ([paper](https://arxiv.org/pdf/2009.12005.pdf)\|[code](https://github.com/zlinao/MinTL)) | **19.4** | 73.7 | 65.4 | 89.0|14.78 | 1.81 | 297  | 2525  |
 | UBAR ([paper](https://arxiv.org/abs/2012.03539)\|[code](https://github.com/TonyNemo/UBAR-MultiWOZ))  | 17.6 | **83.4** | 70.3 | 94.4|13.54 | 2.10 | 478  | 5238  |

--- a/README.md
+++ b/README.md
@@ -86,15 +86,16 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 | PPTOD ([paper](https://arxiv.org/abs/2109.14739)\|[code](https://github.com/awslabs/pptod))  | 18.2 | 83.1 | **72.7** | **96.1**|12.73 | 1.88 | 301  | 2538  |
 
 **Policy optimization models**, i.e. those that use also the ground-truth dialog states.
+##### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
-| Model              | BLEU | Inform  | Success  | Av. len. | CBE | #uniq. words | #uniq. 3-grams |
-| ------------------ | -----:| -------:| --------:| ---------:| -----------------:| -------------:| -------------:|
-| MarCo ([paper](https://arxiv.org/pdf/2004.12363.pdf)\|[code](https://github.com/InitialBug/MarCo-Dialog))   | 17.3 | 94.5 | 87.2 | 16.01 | **1.94** | 319 | **3002** | 
-| HDSA ([paper](https://arxiv.org/pdf/1905.12866.pdf)\|[code](https://github.com/wenhuchen/HDSA-Dialog))    | **20.7** | 87.9 | 79.4 | 14.42 | 1.64 | 259 | 2019 |
-| HDNO ([paper](https://arxiv.org/pdf/2006.06814.pdf)\|[code](https://github.com/mikezhang95/HDNO))    | 17.8 | 93.3 | 83.4 | 14.96 | 0.84 | 103 | 315  |
-| SFN ([paper](https://arxiv.org/pdf/1907.10016.pdf)\|[code](https://github.com/Shikib/structured_fusion_networks))     | 14.1 | 93.4 | 82.3 | 14.93 | 1.63 | 188 | 1218 |
-| UniConv ([paper](https://arxiv.org/pdf/2004.14307.pdf)\|[code](https://github.com/henryhungle/UniConv)) | 18.1 | 66.7 | 58.7 | 14.17 | 1.79 | **338** | 2932 |
-| LAVA ([paper](https://arxiv.org/abs/2011.09378)\|[code](https://gitlab.cs.uni-duesseldorf.de/general/dsml/lava-public/-/tree/master/experiments_woz/sys_config_log_model/2020-05-12-14-51-49-actz_cat))    | 10.8 | **95.9** | **93.5** | 13.28 | 1.27 | 176 | 708  |
+| Model              | BLEU | Inform  | Success  | Combined Score|Av. len. | CBE | #uniq. words | #uniq. 3-grams |
+| ------------------ | -----:| -------:| --------:| ---------:|---------:| -----------------:| -------------:| -------------:|
+| MarCo ([paper](https://arxiv.org/pdf/2004.12363.pdf)\|[code](https://github.com/InitialBug/MarCo-Dialog))   | 17.3 | 94.5 | 87.2 | |16.01 | **1.94** | 319 | **3002** | 
+| HDSA ([paper](https://arxiv.org/pdf/1905.12866.pdf)\|[code](https://github.com/wenhuchen/HDSA-Dialog))    | **20.7** | 87.9 | 79.4 | |14.42 | 1.64 | 259 | 2019 |
+| HDNO ([paper](https://arxiv.org/pdf/2006.06814.pdf)\|[code](https://github.com/mikezhang95/HDNO))    | 17.8 | 93.3 | 83.4 | |14.96 | 0.84 | 103 | 315  |
+| SFN ([paper](https://arxiv.org/pdf/1907.10016.pdf)\|[code](https://github.com/Shikib/structured_fusion_networks))     | 14.1 | 93.4 | 82.3 | |14.93 | 1.63 | 188 | 1218 |
+| UniConv ([paper](https://arxiv.org/pdf/2004.14307.pdf)\|[code](https://github.com/henryhungle/UniConv)) | 18.1 | 66.7 | 58.7 | |14.17 | 1.79 | **338** | 2932 |
+| LAVA ([paper](https://arxiv.org/abs/2011.09378)\|[code](https://gitlab.cs.uni-duesseldorf.de/general/dsml/lava-public/-/tree/master/experiments_woz/sys_config_log_model/2020-05-12-14-51-49-actz_cat))    | 10.8 | **95.9** | **93.5** | |13.28 | 1.27 | 176 | 708  |
 
 
 ### Older results

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 
 | Model              | BLEU | Inform  | Success  | Combined Score|Av. len. | CBE | #uniq. words | #uniq. 3-grams |
 | ------------------ | -----:| -------:| --------:| ---------:|---------:| -----------------:| -------------:| -------------:| 
-| DAMD ([paper](https://arxiv.org/abs/1911.10484)\|[code](https://github.com/thu-spmi/damd-multiwoz))  | 16.4 | 57.9 | 47.6 | |14.27 | 1.65 | 212  | 1755  |
-| MinTL ([paper](https://arxiv.org/pdf/2009.12005.pdf)\|[code](https://github.com/zlinao/MinTL)) | **19.4** | 73.7 | 65.4 | |14.78 | 1.81 | 297  | 2525  |
-| UBAR ([paper](https://arxiv.org/abs/2012.03539)\|[code](https://github.com/TonyNemo/UBAR-MultiWOZ))  | 17.6 | **83.4** | 70.3 | |13.54 | 2.10 | 478  | 5238  |
-| SOLOIST ([paper](https://arxiv.org/abs/2005.05298))  | 13.6 | 82.3 | 72.4 | 18.45 | **2.41** | **615**  | **7923**  |
-| AuGPT ([paper](https://arxiv.org/abs/2102.05126)\|[code](https://github.com/ufal/augpt)) | 16.8 | 76.6 | 60.5 | |12.90 | 2.15 | 608  | 5843  |
-| LABES ([paper](https://arxiv.org/pdf/2009.08115v3.pdf)\|[code](https://github.com/thu-spmi/LABES)) | 18.9 | 68.5 | 58.1 | |14.20 | 1.83 | 374  | 3228  |
-| DoTS ([paper](https://arxiv.org/pdf/2103.06648.pdf))  | 16.8 | 80.4 | 68.7 | |14.66 | 2.10 | 411  | 5162  |
-| PPTOD ([paper](https://arxiv.org/abs/2109.14739)\|[code](https://github.com/awslabs/pptod))  | 18.2 | 83.1 | **72.7** | |12.73 | 1.88 | 301  | 2538  |
+| DAMD ([paper](https://arxiv.org/abs/1911.10484)\|[code](https://github.com/thu-spmi/damd-multiwoz))  | 16.4 | 57.9 | 47.6 | 84.8|14.27 | 1.65 | 212  | 1755  |
+| MinTL ([paper](https://arxiv.org/pdf/2009.12005.pdf)\|[code](https://github.com/zlinao/MinTL)) | **19.4** | 73.7 | 65.4 | 89.0|14.78 | 1.81 | 297  | 2525  |
+| UBAR ([paper](https://arxiv.org/abs/2012.03539)\|[code](https://github.com/TonyNemo/UBAR-MultiWOZ))  | 17.6 | **83.4** | 70.3 | 94.4|13.54 | 2.10 | 478  | 5238  |
+| SOLOIST ([paper](https://arxiv.org/abs/2005.05298))  | 13.6 | 82.3 | 72.4 | 90.9|18.45 | **2.41** | **615**  | **7923**  |
+| AuGPT ([paper](https://arxiv.org/abs/2102.05126)\|[code](https://github.com/ufal/augpt)) | 16.8 | 76.6 | 60.5 |85.4 |12.90 | 2.15 | 608  | 5843  |
+| LABES ([paper](https://arxiv.org/pdf/2009.08115v3.pdf)\|[code](https://github.com/thu-spmi/LABES)) | 18.9 | 68.5 | 58.1 | 82.2|14.20 | 1.83 | 374  | 3228  |
+| DoTS ([paper](https://arxiv.org/pdf/2103.06648.pdf))  | 16.8 | 80.4 | 68.7 | 91.4|14.66 | 2.10 | 411  | 5162  |
+| PPTOD ([paper](https://arxiv.org/abs/2109.14739)\|[code](https://github.com/awslabs/pptod))  | 18.2 | 83.1 | **72.7** | **96.1**|12.73 | 1.88 | 301  | 2538  |
 
 **Policy optimization models**, i.e. those that use also the ground-truth dialog states.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 
 **End-to-end models**, i.e. those that use only the context as input. 
 
-### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
+###### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
 | Model              | BLEU | Inform  | Success  | Av. len. | CBE | #uniq. words | #uniq. 3-grams |
 | ------------------ | -----:| -------:| --------:| ---------:| -----------------:| -------------:| -------------:| 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 | Reference corpus &nbsp; | -    | 93.7 | 90.9 | 14.00 | 3.01 | 1407 | 23877 | 
 
 **End-to-end models**, i.e. those that use only the context as input. 
-
 ##### Combined Score = (INFORM	+ SUCCESS)*0.5 + BLEU
 
 | Model              | BLEU | Inform  | Success  | Combined Score|Av. len. | CBE | #uniq. words | #uniq. 3-grams |


### PR DESCRIPTION
Add the widely used combine score (combined score = 0.5 * (Success + Inform) + BLEU) metric into the response generation leaderboard, serving as the overall quality measurement of different systems. 