### PR TITLE
resolve issue with json-decoding of taxi_db.json

### DIFF
--- a/db/taxi_db.json
+++ b/db/taxi_db.json
@@ -1,5 +1,7 @@
 [
-  "taxi_colors" : ["black","white","red","yellow","blue","grey"],
-  "taxi_types":  ["toyota","skoda","bmw","honda","ford","audi","lexus","volvo","volkswagen","tesla"],
-  "taxi_phone": ["^[0-9]{10}$"]
+  {
+    "taxi_colors" : ["black","white","red","yellow","blue","grey"],
+    "taxi_types":  ["toyota","skoda","bmw","honda","ford","audi","lexus","volvo","volkswagen","tesla"],
+    "taxi_phone": ["^[0-9]{10}$"]
+  }
 ]


### PR DESCRIPTION
Previously, `db/taxi_db.json` could not be loaded via `json.load`:

```python
In [1]: with open('db/taxi_db.json', 'r') as f:
   ...:     import json
   ...:     data = json.load(f)
   ...:
---------------------------------------------------------------------------
JSONDecodeError                           Traceback (most recent call last)
<ipython-input-1-49c90b139172> in <module>
      1 with open('db/taxi_db.json', 'r') as f:
      2     import json
----> 3     data = json.load(f)
      4
...

JSONDecodeError: Expecting ',' delimiter: line 2 column 17 (char 18)
```
The fix in this PR wraps the contents in curly braces to have a list with a single `dict`  item. This seems somewhat different in structure than the other `[domain]_db.json` files, where each item is an instance of a hotel, restaurant, etc, but it does seem to be how this file was [handled in other works using MultiWOZ](https://github.com/TonyNemo/UBAR-MultiWOZ/blob/master/db/taxi_db.json). Let me know if this file should actually have a different structure and I can try to fix another way!