### PR TITLE
Add RSTOD benchmarks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The belief state have three sections: semi, book and booked. Semi refers to slot
 | DoTS ([paper](https://arxiv.org/pdf/2103.06648.pdf))  | 16.8 | 80.4 | 68.7 | 91.4|14.66 | 2.10 | 411  | 5162  |
 | UBAR ([paper](https://arxiv.org/abs/2012.03539)\|[code](https://github.com/TonyNemo/UBAR-MultiWOZ))  | 17.6 | 83.4 | 70.3 | 94.4|13.54 | 2.10 | 478  | 5238  |
 | PPTOD ([paper](https://arxiv.org/abs/2109.14739)\|[code](https://github.com/awslabs/pptod))  | 18.2 | 83.1 | 72.7 | 96.1|12.73 | 1.88 | 301  | 2538  |
+| RSTOD ([paper](https://arxiv.org/abs/2208.07097)\|[code](https://github.com/radi-cho/rstod))  | 18.0 | 83.5 | 75.0 | 97.3 | 13.64 | 1.84 | 376  | 3162  |
 | BORT ([paper](https://arxiv.org/abs/2205.02471)\|[code](https://github.com/JD-AI-Research-NLP/BORT))  | 17.9 | 85.5 | **77.4** | 99.4|14.91 | 1.88 | 294  | 2492  |
 | MTTOD ([paper](https://aclanthology.org/2021.findings-emnlp.112.pdf)\|[code](https://github.com/bepoetree/MTTOD))  | 19.0 | **85.9** | 76.5 | **100.2**|13.94 | 1.93 | 514  | 4066  |
 | GALAXY ([paper](https://arxiv.org/abs/2111.14592)\|[code](https://github.com/siat-nlp/GALAXY)) |**19.64**| 85.4 | 75.7 |**100.2**| 13.39 | 1.75 | 295 | 2275 |


### PR DESCRIPTION
Hello,

We've conducted a [study](https://arxiv.org/abs/2208.07097) to test multiple auxiliary response selection tasks on MultiWOZ 2.1 with a T5-based architecture - [RSTOD](https://github.com/radi-cho/rstod). Then we re-evaluated its variants on MultiWOZ 2.2 with the official evaluation scripts and the outputs of our best performing model were sent to  https://github.com/Tomiinek/MultiWOZ_Evaluation/pull/12. Checkpoints can be found [here](https://drive.google.com/drive/folders/1W7MoU2LfOeaVND0BCGtWVJ-lJqqK0CDj). We would like to request the inclusion of our work in the benchmarks leaderboard.

Best Regards,
Radostin Cholakov